### PR TITLE
feat: Add weekly cron to sync signatures branch to main

### DIFF
--- a/.github/workflows/sync-cla-signatures.yaml
+++ b/.github/workflows/sync-cla-signatures.yaml
@@ -1,0 +1,44 @@
+name: Sync CLA Signatures to Main
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Every Monday at 9am UTC
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check for pending signatures
+        id: check
+        run: |
+          AHEAD=$(gh api repos/safe-global/cla-signatures/compare/main...signatures \
+            --jq '.ahead_by' 2>/dev/null || echo "0")
+          echo "ahead_by=$AHEAD" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create PR for pending signatures
+        if: steps.check.outputs.ahead_by != '0'
+        run: |
+          EXISTING=$(gh pr list \
+            --repo safe-global/cla-signatures \
+            --head signatures \
+            --base main \
+            --json number \
+            --jq '.[0].number')
+          if [ -z "$EXISTING" ]; then
+            gh pr create \
+              --repo safe-global/cla-signatures \
+              --base main \
+              --head signatures \
+              --title "chore: Merge pending CLA signatures" \
+              --body "${{ steps.check.outputs.ahead_by }} signature(s) pending review.\n\ncc @safe-global/platform-team"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

  - Adds a weekly cron workflow (every Monday 9am UTC) that checks if the `signatures` branch is ahead of `main`
  - If there are pending signatures, creates a PR from `signatures` → `main` and pings `@safe-global/platform-team` for review
  - Idempotent: skips PR creation if one already exists
  - Can also be triggered manually via `workflow_dispatch`

  ## Context

  The CLA composite action now stores signatures in the `signatures` branch instead of `main` to  bypass the `safe-enterprise-default-branches` ruleset (which requires PRs + `@safe.global` email for direct pushes). This cron workflow closes the loop by ensuring pending signatures are periodically reviewed and merged.

  ## Test plan

  - [ ] Trigger manually via `workflow_dispatch` with no pending signatures → workflow exits
  without creating a PR
  - [ ] Trigger manually with `signatures` branch ahead of `main` → PR is created with correct
  title and body
  - [ ] Trigger again while PR already exists → no duplicate PR is created